### PR TITLE
Initialize Terraform scaffold with environment and module placeholders

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,14 @@
+name: Terraform
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # TODO: Add steps for Terraform init/plan/apply using TF-via-PR action

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+
+# CLI configuration files
+tfplan
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Terraform Service Template
+
+This repository provides a baseline structure for managing multiple Azure environments with Terraform. It includes core configuration files, environment-specific variable sets, and placeholders for reusable modules and CI/CD workflows.
+
+## Repository Layout
+
+- **main.tf** – Entry point for resources and module calls.
+- **variables.tf** – Shared variable declarations.
+- **outputs.tf** – Shared output values.
+- **providers.tf** – Terraform version and provider requirements.
+- **backend.tf** – Template for remote state configuration.
+- **env/** – Environment-specific variable files (`dev.tfvars`, `staging.tfvars`, `prod.tfvars`).
+- **modules/** – Local modules such as `network` and `storage`.
+- **.github/workflows/** – Placeholder GitHub Actions workflow for plan and apply via pull requests.
+
+Update these files with real infrastructure definitions as the project evolves.

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,10 @@
+# Remote state backend configuration template
+
+# terraform {
+#   backend "azurerm" {
+#     resource_group_name  = "<rg-name>"
+#     storage_account_name = "<storage-account>"
+#     container_name       = "<container>"
+#     key                  = "<statefile>"
+#   }
+# }

--- a/env/dev.tfvars
+++ b/env/dev.tfvars
@@ -1,0 +1,2 @@
+environment = "dev"
+location    = "uksouth"

--- a/env/prod.tfvars
+++ b/env/prod.tfvars
@@ -1,0 +1,2 @@
+environment = "prod"
+location    = "uksouth"

--- a/env/staging.tfvars
+++ b/env/staging.tfvars
@@ -1,0 +1,2 @@
+environment = "staging"
+location    = "uksouth"

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,3 @@
+# Main Terraform configuration
+
+# TODO: Add resources and module invocations here.

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,1 @@
+# Network module resources will be defined here.

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,1 @@
+# Output values for the network module

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,1 @@
+# Input variables for the network module

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,1 @@
+# Storage module resources will be defined here.

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,0 +1,1 @@
+# Output values for the storage module

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,1 @@
+# Input variables for the storage module

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+# Shared output values
+
+# TODO: Define outputs as infrastructure is added.

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 1.0.0"
+  # TODO: Declare required providers here
+}
+
+# TODO: Configure providers (e.g., azurerm)

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+# Shared variable declarations
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add core Terraform files for configuration, variables, outputs, providers, and backend template
- scaffold environment-specific tfvars and reusable module placeholders
- introduce GitHub Actions workflow skeleton for plan/apply via pull requests

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6895fe2fe05c83309e204dd7dbf75102