### PR TITLE
Split workflow into plan and apply jobs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,31 +6,16 @@ on:
     branches: ["main"]
 
 jobs:
-  terraform:
+  tf-plan:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      # TODO: Add steps for Terraform init/plan/apply using TF-via-PR action
-
-name: Terraform
-
-on:
-  pull_request:
-  push:
-    branches: ["main"]
-
-jobs:
-  terraform:
-    runs-on: ubuntu-latest
-
     permissions:
       actions: read
       checks: write
       contents: read
       id-token: write
       pull-requests: write
-
+    outputs:
+      diff: ${{ steps.plan.outputs.diff }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,12 +43,59 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Terraform plan or apply
+      - name: Terraform plan
+        id: plan
         uses: op5dev/tf-via-pr@v13
         with:
           working-directory: .
-          command: ${{ github.event_name == 'push' && 'apply' || 'plan' }}
-          arg-lock: ${{ github.event_name == 'push' }}
-          plan-encrypt: ${{ secrets.PASSPHRASE }}
+          command: plan
+          plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
+          validate: true
+          format: true
+
+  tf-apply:
+    needs: tf-plan
+    if: github.event_name == 'push' && needs.tf-plan.outputs.diff != ''
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Create plugin cache
+        run: |
+          mkdir -p $HOME/.terraform.d/plugin-cache
+          echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> $GITHUB_ENV
+
+      - name: Cache Terraform providers
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: terraform-${{ runner.os }}-${{ hashFiles('.terraform.lock.hcl') }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform apply
+        uses: op5dev/tf-via-pr@v13
+        with:
+          working-directory: .
+          command: apply
+          arg-lock: true
+          plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
           validate: true
           format: true

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ This repository provides a baseline structure for managing Azure infrastructure 
 - **.github/dependabot.yml** – Dependabot configuration for Terraform and GitHub Actions updates.
 
 Update these files with real infrastructure definitions as the project evolves.
+
+## Required Secrets
+
+- **TF_PASSPHRASE** – Used to encrypt Terraform plan files in the GitHub Actions workflow.


### PR DESCRIPTION
## Summary
- separate terraform workflow into `tf-plan` and dependent `tf-apply` jobs
- encrypt plan files with `TF_PASSPHRASE` secret
- document `TF_PASSPHRASE` requirement in README

## Testing
- `terraform fmt -check`
- `terraform validate` *(fails: Missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68960870a8a88330af120d057f1a7da7