### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   determine-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/v1vhm/template-terraform-service/security/code-scanning/2](https://github.com/v1vhm/template-terraform-service/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the `determine-matrix` job in `.github/workflows/terraform.yml`. This block should grant only the minimal permissions required for the job to function. Since the job only checks out code and reads a YAML file, it likely only needs `contents: read`. The change should be made by inserting a `permissions:` block directly under the `runs-on:` line in the `determine-matrix` job definition (after line 10). No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
