### PR TITLE
Limit terraform workflow triggers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -2,8 +2,18 @@ name: Terraform
 
 on:
   pull_request:
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - 'environments.yml'
+      - '.terraform.lock.hcl'
   push:
     branches: ["main"]
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - 'environments.yml'
+      - '.terraform.lock.hcl'
 
 jobs:
   determine-matrix:
@@ -21,6 +31,7 @@ jobs:
 
   tf-plan:
     needs: determine-matrix
+    if: ${{ needs.determine-matrix.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -70,7 +81,7 @@ jobs:
 
   tf-apply:
     needs: [determine-matrix, tf-plan]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.determine-matrix.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,9 +3,19 @@
 name: Terraform
 
 "on":
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - 'environments.yml'
+      - '.terraform.lock.hcl'
   push:
     branches: ["main"]
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - 'environments.yml'
+      - '.terraform.lock.hcl'
 
 jobs:
   determine-matrix:
@@ -98,8 +108,56 @@ jobs:
           validate: true
           format: true
 
-  tf-apply:
+  tf-plan-summary:
     needs: [determine-matrix, tf-plan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Generate summary
+        id: summary
+        uses: actions/github-script@v7
+        env:
+          MATRIX: ${{ needs.determine-matrix.outputs.matrix }}
+        with:
+          script: |
+            const matrix = JSON.parse(process.env.MATRIX);
+            if (matrix[0].name === 'skip') {
+              core.setOutput('summary', 'No environments were deployed.');
+            } else {
+              const { data } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+              });
+              const planJobs = data.jobs.filter(j => j.name.startsWith('tf-plan'))
+              const lines = planJobs.map(j => {
+                const name = j.name.replace('tf-plan (environment: ', '').replace(')', '');
+                return `- ${name}: ${j.conclusion}`;
+              });
+              core.setOutput('summary', lines.join('\n'));
+            }
+      - name: Comment summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          BODY: ${{ steps.summary.outputs.summary }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: process.env.BODY,
+            });
+      - name: Log summary
+        if: github.event_name != 'pull_request'
+        run: echo "${{ steps.summary.outputs.summary }}"
+
+  tf-apply:
+    needs: [determine-matrix, tf-plan-summary]
     if: github.event_name == 'push' && fromJSON(needs.determine-matrix.outputs.matrix)[0].name != 'skip'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,19 +1,11 @@
+# yamllint disable rule:line-length
+---
 name: Terraform
 
-on:
-  pull_request:
-    paths:
-      - '**/*.tf'
-      - '**/*.tfvars'
-      - 'environments.yml'
-      - '.terraform.lock.hcl'
+"on":
+  pull_request: {}
   push:
     branches: ["main"]
-    paths:
-      - '**/*.tf'
-      - '**/*.tfvars'
-      - 'environments.yml'
-      - '.terraform.lock.hcl'
 
 jobs:
   determine-matrix:
@@ -24,14 +16,32 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            terraform:
+              - '**/*.tf'
+              - '**/*.tfvars'
+              - 'environments.yml'
+              - '.terraform.lock.hcl'
       - id: set-matrix
         run: |
+          if [ "${{ steps.changes.outputs.terraform }}" != "true" ]; then
+            echo 'matrix=[{"name":"skip"}]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           matrix=$(yq e -o=json '.environments | sort_by(.order)' environments.yml 2>/dev/null || echo '[]')
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          if [ "$matrix" = "[]" ]; then
+            echo 'matrix=[{"name":"skip"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          fi
 
   tf-plan:
     needs: determine-matrix
-    if: ${{ needs.determine-matrix.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,10 +53,15 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
+      - name: Skip plan
+        if: matrix.environment.name == 'skip'
+        run: echo "No Terraform changes or environments to plan."
       - name: Checkout repository
+        if: matrix.environment.name != 'skip'
         uses: actions/checkout@v4
 
       - name: Azure login
+        if: matrix.environment.name != 'skip'
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -54,22 +69,26 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Create plugin cache
+        if: matrix.environment.name != 'skip'
         run: |
           mkdir -p $HOME/.terraform.d/plugin-cache
           echo "TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache" >> $GITHUB_ENV
 
       - name: Cache Terraform providers
+        if: matrix.environment.name != 'skip'
         uses: actions/cache@v4
         with:
           path: ~/.terraform.d/plugin-cache
           key: terraform-${{ runner.os }}-${{ hashFiles('.terraform.lock.hcl') }}
 
       - name: Setup Terraform
+        if: matrix.environment.name != 'skip'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
 
       - name: Terraform plan ${{ matrix.environment.name }}
+        if: matrix.environment.name != 'skip'
         uses: op5dev/tf-via-pr@v13
         with:
           working-directory: .
@@ -81,7 +100,7 @@ jobs:
 
   tf-apply:
     needs: [determine-matrix, tf-plan]
-    if: github.event_name == 'push' && needs.determine-matrix.outputs.matrix != '[]'
+    if: github.event_name == 'push' && fromJSON(needs.determine-matrix.outputs.matrix)[0].name != 'skip'
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1


### PR DESCRIPTION
## Summary
- trigger Terraform workflow only on Terraform config changes
- skip tf-plan and tf-apply when determine-matrix outputs no environments

## Testing
- `yamllint .github/workflows/terraform.yml` (fails: line too long)
- `terraform fmt -check -recursive`
- `terraform init -backend=false` (fails: Failed to query available provider packages)
- `terraform validate` (fails: Missing required provider)

------
https://chatgpt.com/codex/tasks/task_e_6896d9988b50833090a655aad5283741