### PR TITLE
feat: add backend partial configuration

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -94,7 +94,8 @@ jobs:
         with:
           working-directory: .
           command: plan
-          arg-var-file: env/${{ matrix.environment.name }}.tfvars
+          arg-var-file: ${{ format('{0}/env/{1}.tfvars', github.workspace, matrix.environment.name) }}
+          arg-backend-config: ${{ format('{0}/env/{1}.state.config', github.workspace, matrix.environment.name) }}
           plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
           validate: true
           format: true
@@ -195,7 +196,8 @@ jobs:
           working-directory: .
           command: apply
           arg-lock: true
-          arg-var-file: env/${{ matrix.environment.name }}.tfvars
+          arg-var-file: ${{ format('{0}/env/{1}.tfvars', github.workspace, matrix.environment.name) }}
+          arg-backend-config: ${{ format('{0}/env/{1}.state.config', github.workspace, matrix.environment.name) }}
           plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
           validate: true
           format: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # CLI configuration files
 tfplan
 
+# Environment backend configuration files
+*.state.config
+

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,10 @@
-# Remote state backend configuration template
-
-# terraform {
-#   backend "azurerm" {
-#     resource_group_name  = "<rg-name>"
-#     storage_account_name = "<storage-account>"
-#     container_name       = "<container>"
-#     key                  = "<statefile>"
-#   }
-# }
+# Remote state backend configuration (partial)
+# Backend settings are provided via environment-specific .state.config files in env/
+terraform {
+  backend "azurerm" {
+    resource_group_name  = ""
+    storage_account_name = ""
+    container_name       = ""
+    key                  = ""
+  }
+}

--- a/env/README.md
+++ b/env/README.md
@@ -4,3 +4,17 @@ Store environment-specific Terraform variable definitions in this directory.
 
 Create a separate `.tfvars` file for each environment (e.g., `dev.tfvars`, `staging.tfvars`, `prod.tfvars`).
 These files typically define values such as the environment name, region, and other settings.
+
+Each environment must also provide a corresponding `<environment>.state.config` file. This file supplies
+the backend settings for the `azurerm` remote state and is referenced by the workflow. Its contents
+should define the following keys:
+
+```
+resource_group_name  = "<resource-group>"
+storage_account_name = "<storage-account>"
+container_name       = "<blob-container>"
+key                  = "<state-file-name>"
+```
+These `*.state.config` files must be created for each environment but kept out of source control,
+as they may contain sensitive backend details.
+


### PR DESCRIPTION
## Summary
- enable partial azurerm backend configuration
- document required environment backend config files
- pass backend config files to terraform plan and apply steps

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: Missing required provider)
- `yamllint .github/workflows/terraform.yml`

------
https://chatgpt.com/codex/tasks/task_e_689705b46000833081d4803a0c621594