### PR TITLE
fix: output matrix json in single line

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,7 @@ jobs:
             echo 'matrix=[{"name":"skip"}]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          matrix=$(yq e -o=json '.environments | sort_by(.order)' environments.yml 2>/dev/null || echo '[]')
+          matrix=$(yq e -o=json -I=0 '.environments | sort_by(.order)' environments.yml 2>/dev/null || echo '[]')
           if [ "$matrix" = "[]" ]; then
             echo 'matrix=[{"name":"skip"}]' >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- ensure determine-matrix job outputs JSON on a single line to satisfy GITHUB_OUTPUT format

## Testing
- `terraform fmt -check`
- `printf 'environments:\n  - name: dev\n    order: 1\n' | yq e -o=json -I=0 '.environments | sort_by(.order)' -`


------
https://chatgpt.com/codex/tasks/task_e_68970ee19ffc8330a0c4f6705dbe941f