### PR TITLE
Organize env folder into subdirectories

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -93,8 +93,8 @@ jobs:
         with:
           working-directory: .
           command: plan
-          arg-var-file: ${{ format('{0}/env/{1}.tfvars', github.workspace, matrix.environment.name) }}
-          arg-backend-config: ${{ format('{0}/env/{1}.state.config', github.workspace, matrix.environment.name) }}
+          arg-var-file: ${{ format('{0}/env/{1}/{1}.tfvars', github.workspace, matrix.environment.name) }}
+          arg-backend-config: ${{ format('{0}/env/{1}/{1}.state.config', github.workspace, matrix.environment.name) }}
           plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
           validate: true
           format: true
@@ -194,8 +194,8 @@ jobs:
           working-directory: .
           command: apply
           arg-lock: true
-          arg-var-file: ${{ format('{0}/env/{1}.tfvars', github.workspace, matrix.environment.name) }}
-          arg-backend-config: ${{ format('{0}/env/{1}.state.config', github.workspace, matrix.environment.name) }}
+          arg-var-file: ${{ format('{0}/env/{1}/{1}.tfvars', github.workspace, matrix.environment.name) }}
+          arg-backend-config: ${{ format('{0}/env/{1}/{1}.state.config', github.workspace, matrix.environment.name) }}
           plan-encrypt: ${{ secrets.TF_PASSPHRASE }}
           validate: true
           format: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tfplan
 # Environment backend configuration files
 *.state.config
 
+
+# Allow example state config for demonstration
+!env/example/example.state.config

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository provides a baseline structure for managing Azure infrastructure 
 - **outputs.tf** – Shared output values.
 - **providers.tf** – Terraform version and required providers (AzureRM and Port).
 - **backend.tf** – Template for remote state configuration.
-- **env/** – Placeholder for environment-specific variable files (see `env/README.md`).
+- **env/** – Placeholder for environment-specific variable directories (see `env/README.md`).
 - **modules/** – Placeholder for reusable modules with an example module (`modules/example/`).
 - **.github/workflows/** – GitHub Actions workflow for Terraform plan and apply via pull requests.
 - **.github/dependabot.yml** – Dependabot configuration for Terraform and GitHub Actions updates.

--- a/backend.tf
+++ b/backend.tf
@@ -1,5 +1,5 @@
 # Remote state backend configuration (partial)
-# Backend settings are provided via environment-specific .state.config files in env/
+# Backend settings are provided via environment-specific .state.config files in env/<environment>/<environment>.state.config
 terraform {
   backend "azurerm" {
     resource_group_name  = ""

--- a/env/README.md
+++ b/env/README.md
@@ -12,6 +12,8 @@ location       = "<location>"
 resource_group = "<resource group name>"
 ```
 
+These `.tfvars` files can include additional variables as needed. 
+
 - `<environment>.state.config` providing backend settings for the `azurerm` remote state:
 
 ```
@@ -20,6 +22,4 @@ storage_account_name = "<storage-account>"
 container_name       = "<blob-container>"
 key                  = "<state-file-name>"
 ```
-
-These `.tfvars` files can include additional variables as needed. The `.state.config` files typically contain sensitive information and should not be committed to source control. The `example/` folder included here demonstrates the expected structure.
 

--- a/env/README.md
+++ b/env/README.md
@@ -2,18 +2,17 @@
 
 Store environment-specific Terraform variable definitions in this directory.
 
-Create a separate `.tfvars` file for each environment (e.g., `dev.tfvars`, `staging.tfvars`, `prod.tfvars`).
-This file must contain the following variables:
+Each environment should live in its own subdirectory (e.g., `dev/`, `staging/`, `prod/`). Inside that directory, create:
 
-environment    = "<enviromnent name>"
+- `<environment>.tfvars` containing:
+
+```
+environment    = "<environment name>"
 location       = "<location>"
 resource_group = "<resource group name>"
+```
 
-It can be further customised with additional variables relevant to your deployment.
-
-Each environment must also provide a corresponding `<environment>.state.config` file. This file supplies
-the backend settings for the `azurerm` remote state and is referenced by the workflow. Its contents
-should define the following keys:
+- `<environment>.state.config` providing backend settings for the `azurerm` remote state:
 
 ```
 resource_group_name  = "<resource-group>"
@@ -21,6 +20,6 @@ storage_account_name = "<storage-account>"
 container_name       = "<blob-container>"
 key                  = "<state-file-name>"
 ```
-These `*.state.config` files must be created for each environment but kept out of source control,
-as they may contain sensitive backend details.
+
+These `.tfvars` files can include additional variables as needed. The `.state.config` files typically contain sensitive information and should not be committed to source control. The `example/` folder included here demonstrates the expected structure.
 

--- a/env/example/example.state.config
+++ b/env/example/example.state.config
@@ -1,0 +1,4 @@
+resource_group_name  = "rg-example"
+storage_account_name = "stexample"
+container_name       = "tfstate"
+key                  = "example.tfstate"

--- a/env/example/example.tfvars
+++ b/env/example/example.tfvars
@@ -1,0 +1,3 @@
+environment    = "example"
+location       = "westeurope"
+resource_group = "rg-example"


### PR DESCRIPTION
## Summary
- document new env/<env> folder structure and add example files
- update workflow and backend references to nested env paths
- allow example state config through .gitignore

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `yamllint .github/workflows/terraform.yml`


------
https://chatgpt.com/codex/tasks/task_e_6897250b84d0833098e6f6048ec8d597