### PR TITLE
Add non-interactive cookiecutter generation test

### DIFF
--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -1,0 +1,46 @@
+name: cookiecutter
+
+on:
+  push:
+    paths:
+      - 'cookiecutter.json'
+      - '{{cookiecutter.repo_name}}/**'
+  pull_request:
+    paths:
+      - 'cookiecutter.json'
+      - '{{cookiecutter.repo_name}}/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cookiecutter pyflakes
+          TMP_LINT_DIR="$(mktemp -d)"
+          echo "TMP_LINT_DIR=$TMP_LINT_DIR" >> $GITHUB_ENV
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest "$TMP_LINT_DIR"
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash -s -- -b "$TMP_LINT_DIR"
+          sudo apt-get update && sudo apt-get install -y shellcheck
+          echo "$TMP_LINT_DIR" >> $GITHUB_PATH
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+      - name: Generate project
+        run: cookiecutter --no-input --output-dir /tmp/test "$GITHUB_WORKSPACE"
+      - name: Lint and validate
+        run: |
+          cd "$(ls -d /tmp/test/*)"
+          actionlint .github/workflows/*.yml
+          tflint --format=compact
+          pyflakes .
+          find . -name '*.sh' -exec shellcheck {} +
+          terraform fmt -check
+          terraform init -backend=false
+          terraform validate
+          rm -rf .terraform


### PR DESCRIPTION
## Summary
- add CI workflow to generate template with `--no-input`
- run actionlint, tflint, pyflakes, shellcheck, and terraform validation on generated project

## Testing
- `pre-commit run --files .github/workflows/cookiecutter.yml`
- `cookiecutter . --no-input --output-dir /tmp/test-template`
- `actionlint .github/workflows/*.yml`
- `tflint --format=compact`
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_689b8d96cf508330840a09adf40cadd8