### PR TITLE
Add Port metadata variables to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ This repository packages a Terraform service as a [Cookiecutter](https://cookiec
 3. Follow the prompts for:
    - `project_name` – human readable name of your service.
    - `project_slug` – repository folder name derived from `project_name`.
+   - `repo_name` – Git repository name; defaults to `project_slug`.
    - `description` – short summary of the service.
+   - `port_service_name` – display name for the service in Port.
+   - `port_service_identifier` – unique service identifier in Port.
+   - `port_repository_identifier` – Port entity identifier for this repository.
+   - `port_cost_centre` – cost centre or billing code.
+   - `port_owning_team` – team responsible for the service.
+   - `port_owning_team_identifier` – unique identifier for the owning team in Port.
+
+These Port-related values surface in `.provisioning/repository-config.yml` during repository provisioning.
 
 The template will produce a new directory named after `project_slug` containing a starter Terraform configuration.
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,19 @@ This repository packages a Terraform service as a [Cookiecutter](https://cookiec
    ```
 
 3. Follow the prompts for:
-   - `project_name` – human readable name of your service.
-   - `project_slug` – repository folder name derived from `project_name`.
-   - `repo_name` – Git repository name; defaults to `project_slug`.
    - `description` – short summary of the service.
    - `port_service_name` – display name for the service in Port.
    - `port_service_identifier` – unique service identifier in Port.
-   - `port_repository_identifier` – Port entity identifier for this repository.
+   - `port_repository_identifier` – Port entity identifier for this repository, in the format `<owner>/<repository>`.
    - `port_cost_centre` – cost centre or billing code.
    - `port_owning_team` – team responsible for the service.
    - `port_owning_team_identifier` – unique identifier for the owning team in Port.
 
+`project_name` is set to `port_service_name`, and `project_slug` uses the repository portion of `port_repository_identifier`.
+
 These Port-related values surface in `.provisioning/repository-config.yml` during repository provisioning.
 
-The template will produce a new directory named after `project_slug` containing a starter Terraform configuration.
+The template will produce a new directory named after the repository from `port_repository_identifier` containing a starter Terraform configuration.
 
 ## What's Included
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,12 +1,11 @@
 {
-  "project_name": "Terraform Service Template",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-  "repo_name": "{{ cookiecutter.project_slug }}",
-  "description": "Baseline structure for managing Azure infrastructure with Terraform and Port.",
   "port_service_name": "Port service display name",
   "port_service_identifier": "port-service-id",
-  "port_repository_identifier": "port-repo-id",
+  "port_repository_identifier": "owner/repository",
   "port_cost_centre": "cc-0000",
   "port_owning_team": "owning-team-name",
-  "port_owning_team_identifier": "owning-team-id"
+  "port_owning_team_identifier": "owning-team-id",
+  "description": "Baseline structure for managing Azure infrastructure with Terraform and Port.",
+  "project_name": "{{ cookiecutter.port_service_name }}",
+  "project_slug": "{{ cookiecutter.port_repository_identifier.split('/')[-1] }}"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,12 @@
 {
   "project_name": "Terraform Service Template",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-  "description": "Baseline structure for managing Azure infrastructure with Terraform and Port."
+  "repo_name": "{{ cookiecutter.project_slug }}",
+  "description": "Baseline structure for managing Azure infrastructure with Terraform and Port.",
+  "port_service_name": "Port service display name",
+  "port_service_identifier": "port-service-id",
+  "port_repository_identifier": "port-repo-id",
+  "port_cost_centre": "cc-0000",
+  "port_owning_team": "owning-team-name",
+  "port_owning_team_identifier": "owning-team-id"
 }

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -4,6 +4,19 @@
 
 It includes core configuration files, placeholders for environment variable sets and reusable modules, and CI/CD workflow scaffolding.
 
+## Port Metadata
+
+This project captures several Port-related attributes during generation:
+
+- `{{ cookiecutter.port_service_name }}` – display name for the service in Port.
+- `{{ cookiecutter.port_service_identifier }}` – unique identifier for the service.
+- `{{ cookiecutter.port_repository_identifier }}` – Port entity identifier for this repository.
+- `{{ cookiecutter.port_cost_centre }}` – cost centre or billing code.
+- `{{ cookiecutter.port_owning_team }}` – owning team name.
+- `{{ cookiecutter.port_owning_team_identifier }}` – unique identifier for the owning team.
+
+These values surface in `.provisioning/repository-config.yml` when provisioning the repository.
+
 ## Repository Layout
 
 - **main.tf** – Entry point for resources and module calls.

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -10,7 +10,7 @@ This project captures several Port-related attributes during generation:
 
 - `{{ cookiecutter.port_service_name }}` – display name for the service in Port.
 - `{{ cookiecutter.port_service_identifier }}` – unique identifier for the service.
-- `{{ cookiecutter.port_repository_identifier }}` – Port entity identifier for this repository.
+- `{{ cookiecutter.port_repository_identifier }}` – Port entity identifier for this repository in the format `<owner>/<repository>`.
 - `{{ cookiecutter.port_cost_centre }}` – cost centre or billing code.
 - `{{ cookiecutter.port_owning_team }}` – owning team name.
 - `{{ cookiecutter.port_owning_team_identifier }}` – unique identifier for the owning team.


### PR DESCRIPTION
## Summary
- add Port metadata variables and keep repo_name in cookiecutter.json
- document Port variables and link to provisioning config

## Testing
- `cookiecutter --no-input --output-dir /tmp/test-template . project_name="Demo Service" project_slug="demo-service" repo_name="demo-service" description="Example service" port_service_name="Demo Service" port_service_identifier="demo-service" port_repository_identifier="demo-service-repo" port_cost_centre="cc-1234" port_owning_team="platform-team" port_owning_team_identifier="platform-team-id"`
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `actionlint`
- `tflint --format=compact`
- `pyflakes .`
- `find . -name '*.sh' -exec shellcheck {} +`


------
https://chatgpt.com/codex/tasks/task_e_689ba60e4cc083308fb21ee57d7c3ee7