### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -1,5 +1,8 @@
 name: cookiecutter
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/v1vhm/template-terraform-service/security/code-scanning/4](https://github.com/v1vhm/template-terraform-service/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs local validation/linting, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block should be added at the root level of the workflow file (above `jobs:`) to apply to all jobs in the workflow. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
