### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Validate repository provisioning config
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/v1vhm/template-terraform-service/security/code-scanning/3](https://github.com/v1vhm/template-terraform-service/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (to check out code and run validation), set `contents: read` at the workflow level (top-level, after the `name` and before `on`). This ensures all jobs in the workflow inherit these minimal permissions, reducing the risk of privilege escalation. No changes to the steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
