### PR TITLE
Normalize Port identifiers to lowercase

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,5 +13,5 @@
   "user_some_variable": "Some user defined variable for testing",
   "description": "{{ cookiecutter.port_service_description }}",
   "project_name": "{{ cookiecutter.port_service_name }}",
-  "project_slug": "{{ cookiecutter.port_service_identifier }}"
+  "project_slug": "{{ cookiecutter.port_service_identifier | lower }}"
 }

--- a/{{cookiecutter.project_slug}}/port.yml
+++ b/{{cookiecutter.project_slug}}/port.yml
@@ -1,26 +1,26 @@
-- identifier: {{ cookiecutter.port_repo_owner }}/{{ cookiecutter.port_service_identifier }}
-  title: {{ cookiecutter.port_service_identifier }}
+- identifier: {{ cookiecutter.port_repo_owner | lower }}/{{ cookiecutter.port_service_identifier | lower }}
+  title: {{ cookiecutter.port_service_identifier | lower }}
   blueprint: githubRepository
   properties:
     readme: file://README.md
-    url: https://github.com/{{ cookiecutter.port_repo_owner }}/{{ cookiecutter.port_service_identifier }}
+    url: https://github.com/{{ cookiecutter.port_repo_owner | lower }}/{{ cookiecutter.port_service_identifier | lower }}
     defaultBranch: main
     visibility: {{ cookiecutter.port_repo_visibility }}
-    sshUrl: ssh://github.com/{{ cookiecutter.port_repo_owner }}/{{ cookiecutter.port_service_identifier }}.git
+    sshUrl: ssh://github.com/{{ cookiecutter.port_repo_owner | lower }}/{{ cookiecutter.port_service_identifier | lower }}.git
   relations:
     githubTeams:
-      - {{ cookiecutter.port_owning_team_slug }}
-- identifier: {{ cookiecutter.port_service_identifier }}
+      - {{ cookiecutter.port_owning_team_slug | lower }}
+- identifier: {{ cookiecutter.port_service_identifier | lower }}
   title: {{ cookiecutter.port_service_name }}
   blueprint: service
   teams:
-  - {{ cookiecutter.port_owning_team_slug }}
+  - {{ cookiecutter.port_owning_team_slug | lower }}
   icon: Terraform
   properties:
     short_name: {{ cookiecutter.port_service_name }}
   relations:
-    product: {{ cookiecutter.port_product_identifier }}
-    repository: {{ cookiecutter.port_repo_owner }}/{{ cookiecutter.port_service_identifier }}
+    product: {{ cookiecutter.port_product_identifier | lower }}
+    repository: {{ cookiecutter.port_repo_owner | lower }}/{{ cookiecutter.port_service_identifier | lower }}
     service_template: terraform_service
     service_cost_centre: "{{ cookiecutter.port_cost_centre }}"
 


### PR DESCRIPTION
## Summary
- enforce lowercase Port identifiers in generated metadata
- ensure project slug uses lowercase service identifier

## Testing
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `actionlint`
- `tflint --format=compact`
- `pyflakes .`
- `find . -name '*.sh' -exec shellcheck {} +`


------
https://chatgpt.com/codex/tasks/task_e_68a061e034208330bc08890a12bb63c4